### PR TITLE
feat: update Dockerfile and add update script for Cursor application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,18 @@ LABEL maintainer="arfo_dublo@boards.digital" \
       org.opencontainers.image.title="Cursor in browser" \
       org.opencontainers.image.description="Cursor container image allowing access via web browser"
 
-# Set version, display and download link
-ARG CURSOR_VERSION=1.7.46
+# Set display
 ENV DISPLAY=:1
-ENV CURSOR_DOWNLOAD_URL=https://downloads.cursor.com/production/b9e5948c1ad20443a5cecba6b84a3c9b99d62582/linux/x64/Cursor-1.7.46-x86_64.AppImage
 
 # Update and install necessary packages
 RUN echo "**** install packages ****" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends curl fuse python3.11-venv libfuse2 python3-xdg libgtk-3-0 libnotify4 libatspi2.0-0 libsecret-1-0 libnss3 desktop-file-utils fonts-noto-color-emoji git ssh-askpass && \
+    apt-get install -y --no-install-recommends curl fuse python3.11-venv libfuse2 python3-xdg libgtk-3-0 libnotify4 libatspi2.0-0 libsecret-1-0 libnss3 desktop-file-utils fonts-noto-color-emoji git ssh-askpass yad && \
     apt-get autoclean && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
 # Download Cursor AppImage and manage permissions
-RUN curl --location --output Cursor.AppImage $CURSOR_DOWNLOAD_URL && \
+RUN CURSOR_DOWNLOAD_URL=$(python3 -c "import urllib.request, json; response = urllib.request.urlopen('https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable'); data = json.load(response); print(data['downloadUrl'])") && \
+    curl --location --output Cursor.AppImage "$CURSOR_DOWNLOAD_URL" && \
     chmod a+x Cursor.AppImage
 
 
@@ -28,12 +27,23 @@ ENV CUSTOM_PORT="8080" \
     CUSTOM_USER="" \
     PASSWORD="" \
     SUBFOLDER="" \
-    TITLE="Cursor v${CURSOR_VERSION}" \
+    TITLE="Cursor" \
     FM_HOME="/cursor"
 
 # Add local files and Cursor icon
 COPY root/ /
 COPY cursor_icon.png /cursor_icon.png
+
+# Normalize line endings and permissions on copied scripts
+RUN find /defaults /etc/cont-init.d -type f -exec sed -i 's/\r$//' {} +
+
+# When try to open a link, show a popup to the user with the link
+RUN sed -i 's/\r$//' /usr/local/bin/xdg-open && \
+    chmod +x /usr/local/bin/xdg-open
+
+# Update Cursor script
+RUN sed -i 's/\r$//' /usr/local/bin/update-cursor.sh && \
+    chmod +x /usr/local/bin/update-cursor.sh
 
 # Expose ports and volumes
 EXPOSE 8080 8443

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # cursor-in-browser
+
 ## Deploy and use **Cursor - The AI Code Editor** directly in a **web browser**!
 
 This work have been **strongly** influenced by the following repo: https://github.com/sytone/obsidian-remote
@@ -19,7 +20,7 @@ Docker Hub : https://hub.docker.com/r/arfodublo/cursor-in-browser
 
 GitHub Container Registry (ghcr) : https://ghcr.io/arfo-du-blo/cursor-in-browser
 
-### **• Quick run :** 
+### **• Quick run :**
 
 Using **Docker Hub** :
 
@@ -49,27 +50,27 @@ You can replace the **:latest-x64** tag (latest version for AMD processors) by t
 
 ### **• Important notes :**
 
-1. Some buttons are not directly clickable in the UI. **Log in** button is part of those, to use these buttons you will need to copy the link (right click on them then copy) and open them in a new tab. Then follow the log in procedure on Cursor official web site in this **Log in** button example.
+1. Some buttons, such as **Log in**, cannot be clicked directly from the UI due to browser sandbox restrictions. When you try to open an external link, a popup will now appear showing you the URL—just copy it (Ctrl+C) from the dialog and paste it into a new browser tab to continue (for example, to complete log in on the official Cursor website).
 
 2. If you closed Cursor you will be redirected to a black screen. To reopen Cursor right click on this screen a menu will appear with Cursor icon and name. You can simply click on it to open it back.
 
-### **• Environment Variables :** 
+### **• Environment Variables :**
 
-|Environment Variable |	Description|
-|---|---|
-|PUID|	Set the user ID for the container user. 911 by default.|
-|PGID|	Set the group ID for the continer user. 911 by default.|
-|TZ|	Set the Time Zone for the container, should match your TZ. Etc/UTC by default. See List of tz database time zones for valid options.|
-|DOCKER_MODS|	Use to add mods to the container like git. E.g. DOCKER_MODS=linuxserver/mods:universal-git See Docker Mods for details.|
-|INSTALL_PACKAGES|	Use to add package for the container like language pack. E.g. INSTALL_PACKAGES=fonts-noto-cjk fonts-noto-extra And the docker mod linuxserver/mods:universal-package-install is required.|
-|KEYBOARD|	Used to se the keyboard being used for input. E.g. KEYBOARD=en-us-qwerty or KEYBOARD=de-de-qwertz a list of other possible values (not tested) can be found at https://github.com/linuxserver/docker-digikam#keyboard-layouts|
-|CUSTOM_PORT|	Internal port the container listens on for http if it needs to be swapped from the default 3000.|
-|CUSTOM_HTTPS_PORT|	Internal port the container listens on for https if it needs to be swapped from the default 3001.|
-|CUSTOM_USER|	HTTP Basic auth username, abc is default.|
-|PASSWORD|	HTTP Basic auth password, abc is default. If unset there will be no auth|
-|SUBFOLDER|	Subfolder for the application if running a subfolder reverse proxy, need both slashes IE /subfolder/|
-|TITLE|	The page title displayed on the web browser, default "KasmVNC Client".|
-|FM_HOME|	This is the home directory (landing) for the file manager, default "/config".|
+| Environment Variable | Description                                                                                                                                                                                                                   |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PUID                 | Set the user ID for the container user. 911 by default.                                                                                                                                                                       |
+| PGID                 | Set the group ID for the continer user. 911 by default.                                                                                                                                                                       |
+| TZ                   | Set the Time Zone for the container, should match your TZ. Etc/UTC by default. See List of tz database time zones for valid options.                                                                                          |
+| DOCKER_MODS          | Use to add mods to the container like git. E.g. DOCKER_MODS=linuxserver/mods:universal-git See Docker Mods for details.                                                                                                       |
+| INSTALL_PACKAGES     | Use to add package for the container like language pack. E.g. INSTALL_PACKAGES=fonts-noto-cjk fonts-noto-extra And the docker mod linuxserver/mods:universal-package-install is required.                                     |
+| KEYBOARD             | Used to se the keyboard being used for input. E.g. KEYBOARD=en-us-qwerty or KEYBOARD=de-de-qwertz a list of other possible values (not tested) can be found at https://github.com/linuxserver/docker-digikam#keyboard-layouts |
+| CUSTOM_PORT          | Internal port the container listens on for http if it needs to be swapped from the default 3000.                                                                                                                              |
+| CUSTOM_HTTPS_PORT    | Internal port the container listens on for https if it needs to be swapped from the default 3001.                                                                                                                             |
+| CUSTOM_USER          | HTTP Basic auth username, abc is default.                                                                                                                                                                                     |
+| PASSWORD             | HTTP Basic auth password, abc is default. If unset there will be no auth                                                                                                                                                      |
+| SUBFOLDER            | Subfolder for the application if running a subfolder reverse proxy, need both slashes IE /subfolder/                                                                                                                          |
+| TITLE                | The page title displayed on the web browser, default "KasmVNC Client".                                                                                                                                                        |
+| FM_HOME              | This is the home directory (landing) for the file manager, default "/config".                                                                                                                                                 |
 
 ### More details about the image here: https://hub.docker.com/r/arfodublo/cursor-in-browser
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ docker run -d \
 ghcr.io/arfo-du-blo/cursor-in-browser:latest-x64
 ```
 
+### **• Volumes :**
+
+- /config : Configuration files for Cursor.
+- /cursor : Cursor data files.
+
+```
+docker run -d \
+      -v /home/user/cursor-in-browser/config:/config/.config/Cursor \ # Will map your Cursor configuration files in the host system
+      -p 8050:8080 \
+      -e CUSTOM_USER=cursor_user \
+      -e PASSWORD=cursor_password \
+arfodublo/cursor-in-browser:latest-x64
+```
+
 You can replace the **:latest-x64** tag (latest version for AMD processors) by the version and architecture you need (for example replace :latest-x64 by :latest-arm64 if working on ARM CPU or :1.2.3-x64 / :1.2.3-arm64 if you need a specific version).
 
 ### **• Important notes :**

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -6,5 +6,10 @@
                 <command>/Cursor.AppImage --appimage-extract-and-run --no-sandbox --disable-gpu --no-xshm --disable-dev-shm-usage --disable-software-rasterizer</command>
             </action>
         </item>
+        <item label="Download Latest Cursor version" icon="/cursor_icon.png">
+            <action name="Execute">
+                <command>/usr/local/bin/update-cursor.sh</command>
+            </action>
+        </item>
     </menu>
 </openbox_menu>

--- a/root/usr/local/bin/update-cursor.sh
+++ b/root/usr/local/bin/update-cursor.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+API_URL="https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable"
+CURSOR_APP_IMAGE="/Cursor.AppImage"
+
+# Check dependencies
+for cmd in curl python3; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    yad --error --text="Missing required command: $cmd" --width=400 --button=gtk-ok 2>/dev/null || echo "Missing required command: $cmd" >&2
+    exit 1
+  }
+done
+
+# Show progress dialog
+yad --info --no-buttons --text="Checking for Cursor updates..." --fixed --width=300 --height=100 --text-align=center --undecorated 2>/dev/null &
+DIALOG_PID_1=$!
+
+# Fetch latest release info
+json=$(curl -fsSL "$API_URL")
+download_url=$(echo "$json" | python3 -c "import json, sys; data = json.load(sys.stdin); print(data['downloadUrl'])")
+version=$(echo "$json" | python3 -c "import json, sys; data = json.load(sys.stdin); print(data.get('version', 'latest'))")
+
+if [[ -z "$download_url" || "$download_url" == "null" ]]; then
+  kill "$DIALOG_PID_1" 2>/dev/null || true
+  wait "$DIALOG_PID_1" 2>/dev/null || true
+  yad --error --text="Failed to retrieve download URL from API" --fixed --width=300 --height=100 --text-align=center --undecorated --button=gtk-ok 2>/dev/null || echo "Failed to retrieve download URL" >&2
+  exit 1
+fi
+
+# Close the checking dialog
+kill "$DIALOG_PID_1" 2>/dev/null || true
+wait "$DIALOG_PID_1" 2>/dev/null || true
+
+yad --info --text="Latest Cursor version: $version\nDownloading..." --fixed --width=300 --height=100 --text-align=center --undecorated --no-buttons 2>/dev/null &
+DIALOG_PID_2=$!
+
+# Download to a temp file first
+tmpfile=/tmp/Cursor-$version.AppImage
+curl -L --progress-bar -o "$tmpfile" "$download_url" || {
+  rm -f "$tmpfile"
+  kill "$DIALOG_PID_2" 2>/dev/null || true
+  wait "$DIALOG_PID_2" 2>/dev/null || true
+  yad --error --text="Failed to download Cursor" --fixed --width=300 --height=100 --text-align=center --undecorated --button=gtk-ok 2>/dev/null || echo "Failed to download" >&2
+  exit 1
+}
+
+# Close the downloading dialog
+kill "$DIALOG_PID_2" 2>/dev/null || true
+wait "$DIALOG_PID_2" 2>/dev/null || true
+
+# Replace old AppImage (requires root permissions)
+sudo mv "$tmpfile" "$CURSOR_APP_IMAGE"
+sudo chmod +x "$CURSOR_APP_IMAGE"
+
+yad --info --text="✓ Cursor updated to version $version" --fixed --width=300 --height=100 --text-align=center --undecorated --button=gtk-ok 2>/dev/null
+
+exit 0
+

--- a/root/usr/local/bin/xdg-open
+++ b/root/usr/local/bin/xdg-open
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+target="$1"
+log_file="/cursor/opened-links.log"
+
+if [ -n "$target" ]; then
+    printf '%s\n' "$target" >> "$log_file" 2>/dev/null || true
+fi
+
+if command -v yad >/dev/null 2>&1; then
+    if [ -n "$target" ]; then
+        yad --entry \
+            --title="External Link Requested" \
+            --text="Copy (Ctrl+C) this link to open outside the container:" \
+            --entry-text="$target" \
+            --width=500 --button=gtk-ok 2>/dev/null || true
+    else
+        yad --info \
+            --title="External Link Requested" \
+            --text="xdg-open was invoked without a URL or file path." \
+            --width=400 --button=gtk-ok 2>/dev/null || true
+    fi
+else
+    echo "xdg-open intercepted. Target: $target"
+fi
+
+exit 0
+


### PR DESCRIPTION
- Removed hardcoded Cursor version and download URL, replacing it with a dynamic fetch from the API.
- Added a new script to update the Cursor application.
- Introduced a new menu item in the Openbox menu for downloading the latest Cursor version.
- Normalized line endings and permissions for scripts to ensure compatibility.
- Adds a small shim script at /usr/local/bin/xdg-open that intercepts requests to open URLs from inside the container and displays the URL in a yad promp